### PR TITLE
improving color blends for parent-child connections

### DIFF
--- a/solid.tex
+++ b/solid.tex
@@ -2,45 +2,51 @@
 %\usetikzlibrary{...}% tikz package already loaded by 'tikz' option
 \usetikzlibrary{mindmap,trees}
 \begin{document}
-\begin{tikzpicture}[mindmap, grow cyclic, every node/.style=concept, concept color=blue,text=white, 
-  level 1/.append style={level distance=5cm, sibling angle=51},
-  level 2/.append style={level distance=3cm,sibling angle=45},]
-    
-    \node{\Huge{PySAL}}
-	child [concept color=blue!1!olive!70]{ node {\Huge {$\theta$}}
-		child { node { }}
-		child { node { }}
-		child { node { }}
+\begin{tikzpicture}[mindmap,
+                    grow cyclic, 
+                    every node/.style=concept, 
+                    concept color=blue,
+                    shading=ball,
+                    text=white, 
+                    level 1/.append style={level distance=5cm,
+                                           sibling angle=51},
+                    level 2/.append style={level distance=3cm,
+                                           sibling angle=45},]
+    \node[concept,ball color=blue]{\Huge{PySAL}}
+	child [concept color=blue!1!olive!70]{ node [concept,ball color=blue!1!olive!70]{\Huge {$\theta$}}
+		child [concept color=blue!1!olive!70]{ node [concept,ball color=blue!1!olive!70] { }}
+		child [concept color=blue!1!olive!70]{ node [concept,ball color=blue!1!olive!70] { }}
+		child [concept color=blue!1!olive!70]{ node [concept,ball color=blue!1!olive!70] { }}
 	}
-    	child [concept color=blue!1!magenta!70] { node {\Huge{$\gamma$}}
-		child { node {}}
-		child { node {}}
-		child { node {}}
+    	child [concept color=blue!1!magenta!70]{ node [concept,ball color=blue!1!magenta!70]{\Huge{$\gamma$}}
+		child [concept color=blue!1!magenta!70]{ node [concept,ball color=blue!1!magenta!70] { }}
+		child [concept color=blue!1!magenta!70]{ node [concept,ball color=blue!1!magenta!70] { }}
+		child [concept color=blue!1!magenta!70]{ node [concept,ball color=blue!1!magenta!70] { }}
 	}
-	child [concept color=blue!1!teal!70] { node {\Huge{$\tau$} }
-		child { node {}}
-		child { node {}}
-		child { node {}}
+	child [concept color=blue!1!teal!70]{ node [concept,ball color=blue!1!teal!70]{\Huge{$\tau$} }
+		child [concept color=blue!1!teal!70]{ node [concept,ball color=blue!1!teal!70] { }}
+		child [concept color=blue!1!teal!70]{ node [concept,ball color=blue!1!teal!70] { }}
+		child [concept color=blue!1!teal!70]{ node [concept,ball color=blue!1!teal!70] { }}
 	}
-	child [concept color=blue!1!purple!70]{ node {\Huge{$\lambda$}}
-		child { node { }}
-		child { node {}}
-		child { node {}}
+	child [concept color=blue!1!purple!70]{ node [concept,ball color=blue!1!purple!70]{\Huge{$\lambda$}}
+		child [concept color=blue!1!purple!70]{ node [concept,ball color=blue!1!purple!70] { }}
+		child [concept color=blue!1!purple!70]{ node [concept,ball color=blue!1!purple!70] { }}
+		child [concept color=blue!1!purple!70]{ node [concept,ball color=blue!1!purple!70] { }}
 	}
-	child [concept color=blue!1!gray!70]{ node {\Huge{$\alpha$}}
-		child { node { }}
-		child { node {}}
-		child { node { }}
+	child [concept color=blue!1!gray!70]{ node [concept,ball color=blue!1!gray!70]{\Huge{$\alpha$}}
+		child [concept color=blue!1!gray!70]{ node [concept,ball color=blue!1!gray!70] { }}
+		child [concept color=blue!1!gray!70]{ node [concept,ball color=blue!1!gray!70] { }}
+		child [concept color=blue!1!gray!70]{ node [concept,ball color=blue!1!gray!70] { }}
 	}
-	child [concept color=blue!1!blue!20!cyan!60]{ node {\Huge{$W$} }
-		child { node { }}
-		child { node { }}
-		child { node {}}
+	child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60]{\Huge{$\alpha$}}
+		child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60] { }}
+		child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60] { }}
+		child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60] { }}
 	}
-	child [concept color=blue!1!red!70]{ node {\Huge{$\rho$} }
-		child { node {}}
-		child { node {}}
-		child { node {}}
+	child [concept color=blue!1!red!70]{ node [concept,ball color=blue!1!red!70]{\Huge{$\rho$} }
+		child [concept color=blue!1!red!70]{ node [concept,ball color=blue!1!red!70] { }}
+		child [concept color=blue!1!red!70]{ node [concept,ball color=blue!1!red!70] { }}
+		child [concept color=blue!1!red!70]{ node [concept,ball color=blue!1!red!70] { }}
 	}
     	;
 \end{tikzpicture}

--- a/solid.tex
+++ b/solid.tex
@@ -38,7 +38,7 @@
 		child [concept color=blue!1!gray!70]{ node [concept,ball color=blue!1!gray!70] { }}
 		child [concept color=blue!1!gray!70]{ node [concept,ball color=blue!1!gray!70] { }}
 	}
-	child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60]{\Huge{$\alpha$}}
+	child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60]{\Huge{$W$}}
 		child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60] { }}
 		child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60] { }}
 		child [concept color=blue!1!cyan!60]{ node [concept,ball color=blue!1!cyan!60] { }}

--- a/solid.tex
+++ b/solid.tex
@@ -2,41 +2,42 @@
 %\usetikzlibrary{...}% tikz package already loaded by 'tikz' option
 \usetikzlibrary{mindmap,trees}
 \begin{document}
-\begin{tikzpicture}[mindmap,grow cyclic, every node/.style=concept, concept color=blue!100,text=white,
+\begin{tikzpicture}[mindmap, grow cyclic, every node/.style=concept, concept color=blue,text=white, 
   level 1/.append style={level distance=5cm, sibling angle=51},
   level 2/.append style={level distance=3cm,sibling angle=45},]
+    
     \node{\Huge{PySAL}}
-	child [concept color=olive!70]{ node {\Huge {$\theta$}}
+	child [concept color=blue!1!olive!70]{ node {\Huge {$\theta$}}
 		child { node { }}
 		child { node { }}
 		child { node { }}
 	}
-    	child [concept color=magenta!70] { node {\Huge{$\gamma$}}
+    	child [concept color=blue!1!magenta!70] { node {\Huge{$\gamma$}}
 		child { node {}}
 		child { node {}}
 		child { node {}}
 	}
-	child [concept color=teal!70] { node {\Huge{$\tau$} }
+	child [concept color=blue!1!teal!70] { node {\Huge{$\tau$} }
 		child { node {}}
 		child { node {}}
 		child { node {}}
 	}
-	child [concept color=purple!70]{ node {\Huge{$\lambda$}}
+	child [concept color=blue!1!purple!70]{ node {\Huge{$\lambda$}}
 		child { node { }}
 		child { node {}}
 		child { node {}}
 	}
-	child [concept color=gray!70]{ node {\Huge{$\alpha$}}
+	child [concept color=blue!1!gray!70]{ node {\Huge{$\alpha$}}
 		child { node { }}
 		child { node {}}
 		child { node { }}
 	}
-	child [concept color=cyan!70]{ node {\Huge{$W$} }
+	child [concept color=blue!1!blue!20!cyan!60]{ node {\Huge{$W$} }
 		child { node { }}
 		child { node { }}
 		child { node {}}
 	}
-	child [concept color=red!70]{ node {\Huge{$\rho$} }
+	child [concept color=blue!1!red!70]{ node {\Huge{$\rho$} }
 		child { node {}}
 		child { node {}}
 		child { node {}}


### PR DESCRIPTION
Adding `blue!1!` before each color in the cycle for better parent-child color blends.

For example:

```tex
child [concept color=blue!1!olive!70]{ node {\Huge {$\theta$}}
		child { node { }}
		child { node { }}
		child { node { }}
```